### PR TITLE
	Gravatar no more dependent on e-mail

### DIFF
--- a/src/Firehose.Web/Authors/AdamPedley.cs
+++ b/src/Firehose.Web/Authors/AdamPedley.cs
@@ -26,5 +26,7 @@ namespace Firehose.Web.Authors
         public string TwitterHandle => "adpedley";
 
         public DateTime FirstAwarded => new DateTime(2016, 10, 1);
+
+        public string GravatarHash => "";
     }
 }

--- a/src/Firehose.Web/Authors/GeoffreyHuntley.cs
+++ b/src/Firehose.Web/Authors/GeoffreyHuntley.cs
@@ -17,5 +17,7 @@ namespace Firehose.Web.Authors
         public IEnumerable<Uri> FeedUris { get { yield return new Uri("https://ghuntley.com/atom.xml"); } }
 
         public DateTime FirstAwarded => new DateTime(2017, 1, 1);
+
+        public string GravatarHash => "";
     }
 }

--- a/src/Firehose.Web/Authors/GeraldVersluis.cs
+++ b/src/Firehose.Web/Authors/GeraldVersluis.cs
@@ -12,7 +12,7 @@ namespace Firehose.Web.Authors
 
         public string StateOrRegion => "Holland";
 
-        public string EmailAddress => "gerald@verslu.is";
+        public string EmailAddress => "";
 
         public string Title => "Xamarin Developer | Microsoft MVP";
 
@@ -26,5 +26,7 @@ namespace Firehose.Web.Authors
         public string TwitterHandle => "jfversluis";
 
         public DateTime FirstAwarded => new DateTime(2016, 10, 1);
+
+        public string GravatarHash => "f9d4d4211d7956ce3e07e83df0889731";
     }
 }

--- a/src/Firehose.Web/Authors/JimBennett.cs
+++ b/src/Firehose.Web/Authors/JimBennett.cs
@@ -4,19 +4,21 @@ using Firehose.Web.Infrastructure;
 
 namespace Firehose.Web.Authors
 {
-   public class JimBennett : IAmAMicrosoftMVP, IAmAXamarinMVP
-   {
-      public string FirstName => "Jim";
-      public string LastName => "Bennett";
-      public string Title => "Mobile developer at EROAD";
-      public string StateOrRegion => "Auckland, New Zealand";
-      public string EmailAddress => "jim@jimbobbennett.io";
-      public string TwitterHandle => "jimbobbennett";
+    public class JimBennett : IAmAMicrosoftMVP, IAmAXamarinMVP
+    {
+        public string FirstName => "Jim";
+        public string LastName => "Bennett";
+        public string Title => "Mobile developer at EROAD";
+        public string StateOrRegion => "Auckland, New Zealand";
+        public string EmailAddress => "jim@jimbobbennett.io";
+        public string TwitterHandle => "jimbobbennett";
 
-      public Uri WebSite => new Uri("https://jimbobbennett.io/");
-      public IEnumerable<Uri> FeedUris { get { yield return new Uri("https://www.jimbobbennett.io/rss"); } }
+        public Uri WebSite => new Uri("https://jimbobbennett.io/");
+        public IEnumerable<Uri> FeedUris { get { yield return new Uri("https://www.jimbobbennett.io/rss"); } }
 
-      DateTime IAmAXamarinMVP.FirstAwarded => new DateTime(2016, 1, 1);
-      DateTime IAmAMicrosoftMVP.FirstAwarded => new DateTime(2017, 1, 1);
-   }
+        DateTime IAmAXamarinMVP.FirstAwarded => new DateTime(2016, 1, 1);
+        DateTime IAmAMicrosoftMVP.FirstAwarded => new DateTime(2017, 1, 1);
+
+        public string GravatarHash => "";
+    }
 }

--- a/src/Firehose.Web/Authors/KentBoogaart.cs
+++ b/src/Firehose.Web/Authors/KentBoogaart.cs
@@ -26,5 +26,6 @@ namespace Firehose.Web.Authors
         public string TwitterHandle => "kent_boogaart";
 
         public DateTime FirstAwarded => new DateTime(2009, 04, 01);
+        public string GravatarHash => "";
     }
 }

--- a/src/Firehose.Web/Authors/KerryLothrop.cs
+++ b/src/Firehose.Web/Authors/KerryLothrop.cs
@@ -18,5 +18,6 @@ namespace Firehose.Web.Authors
 
         DateTime IAmAMicrosoftMVP.FirstAwarded => new DateTime(2016, 4, 1);
         DateTime IAmAXamarinMVP.FirstAwarded => new DateTime(2016, 5, 27);
+        public string GravatarHash => "";
     }
 }

--- a/src/Firehose.Web/Authors/MarcoKuiper.cs
+++ b/src/Firehose.Web/Authors/MarcoKuiper.cs
@@ -4,19 +4,20 @@ using Firehose.Web.Infrastructure;
 
 namespace Firehose.Web.Authors
 {
-	public class MarcoKuiper : IAmACommunityMember
-	{
-		public IEnumerable<Uri> FeedUris
-		{
-			get { yield return new Uri("http://feeds2.feedburner.com/marcofolio"); }
-		}
+    public class MarcoKuiper : IAmACommunityMember
+    {
+        public IEnumerable<Uri> FeedUris
+        {
+            get { yield return new Uri("http://feeds2.feedburner.com/marcofolio"); }
+        }
 
-		public string EmailAddress => "marco@marcofolio.net";
-		public string FirstName => "Marco";
-		public string LastName => "Kuiper";
-		public string StateOrRegion => "The Netherlands";
-		public string Title => "Code monkey";
-		public string TwitterHandle => "marcofolio";
-		public Uri WebSite => new Uri("http://www.marcofolio.net/");
-	}
+        public string EmailAddress => "marco@marcofolio.net";
+        public string FirstName => "Marco";
+        public string LastName => "Kuiper";
+        public string StateOrRegion => "The Netherlands";
+        public string Title => "Code monkey";
+        public string TwitterHandle => "marcofolio";
+        public Uri WebSite => new Uri("http://www.marcofolio.net/");
+        public string GravatarHash => "";
+    }
 }

--- a/src/Firehose.Web/Authors/TomaszCielecki.cs
+++ b/src/Firehose.Web/Authors/TomaszCielecki.cs
@@ -19,5 +19,6 @@ namespace Firehose.Web.Authors
         public Uri WebSite => new Uri("http://blog.ostebaronen.dk");
         public string TwitterHandle => "Cheesebaron";
         public DateTime FirstAwarded => new DateTime(2015, 1, 1);
+        public string GravatarHash => "";
     }
 }

--- a/src/Firehose.Web/Controllers/FeedController.cs
+++ b/src/Firehose.Web/Controllers/FeedController.cs
@@ -1,4 +1,5 @@
-﻿using System.Linq;
+﻿using System.Collections.Generic;
+using System.Linq;
 using System.Reflection;
 using System.ServiceModel.Syndication;
 using System.Web.Mvc;
@@ -35,7 +36,7 @@ namespace Firehose.Web.Controllers
 
             var items = _combinedFeedSource.Feed.Items
                                            .OrderByDescending(item => item.PublishDate)
-                                           .Take((int) numPosts)
+                                           .Take((int)numPosts)
                                            .ToArray();
 
             var shorterFeed = originalFeed.Clone(false);

--- a/src/Firehose.Web/Infrastructure/GravatarHashingExtensions.cs
+++ b/src/Firehose.Web/Infrastructure/GravatarHashingExtensions.cs
@@ -5,12 +5,16 @@ namespace Firehose.Web.Infrastructure
 {
     public static class GravatarHashingExtensions
     {
-        public static string GravatarImage(this string emailAddress)
+        public static string GravatarImage(this IAmACommunityMember member)
         {
-            var hashedEmailAddress = emailAddress.Trim().ToLowerInvariant().ToMd5Hash().ToLowerInvariant();
             const int size = 200;
+            var hash = member.GravatarHash;
+
+            if (string.IsNullOrWhiteSpace(hash))
+                hash = member.EmailAddress.Trim().ToLowerInvariant().ToMd5Hash().ToLowerInvariant();
+
             var defaultImage = HttpUtility.UrlEncode(ConfigurationManager.AppSettings["DefaultGravatarImage"]);
-            return $"http://www.gravatar.com/avatar/{hashedEmailAddress}.jpg?s={size}&d={defaultImage}";
+            return $"http://www.gravatar.com/avatar/{hash}.jpg?s={size}&d={defaultImage}";
         }
     }
 }

--- a/src/Firehose.Web/Infrastructure/IAmABlogger.cs
+++ b/src/Firehose.Web/Infrastructure/IAmABlogger.cs
@@ -17,6 +17,7 @@ namespace Firehose.Web.Infrastructure
         string Title { get; }
         Uri WebSite { get; }
         string TwitterHandle { get; }
+        string GravatarHash { get; }
     }
 
     public interface IWorkAtXamarin : IAmACommunityMember

--- a/src/Firehose.Web/Views/Feed/Read.cshtml
+++ b/src/Firehose.Web/Views/Feed/Read.cshtml
@@ -16,11 +16,14 @@
     <div class="syndicationItem">
         <h1 class="syndicationItemTitle"><a href="@link" target="_blank">@Html.Raw(item.Title.Text)</a></h1>
         <h2 class="syndicationItemDate">@item.PublishDate.ToString("dd MMMM yyyy")</h2>
-        <img class="syndicationItemPhoto" src="@authorEmail.GravatarImage()" alt="@authorName avatar" />
+        @*<img class="syndicationItemPhoto" src="@authorEmail.GravatarImage()" alt="@authorName avatar" />*@
         <h2 class="syndicationItemByLine">@authorName</h2>
-        <a href="mailto:@authorEmail">@authorEmail</a>
-        <br style="clear: both"/>
-        <hr/>
+        @if (!string.IsNullOrWhiteSpace(@authorEmail))
+        {
+            <a href="mailto:@authorEmail">@authorEmail</a>
+        }
+        <br style="clear: both" />
+        <hr />
         <div class="syndicationItemContent">
             @Html.Raw(html)
         </div>

--- a/src/Firehose.Web/Views/WhoAreWe/BusinessCard.cshtml
+++ b/src/Firehose.Web/Views/WhoAreWe/BusinessCard.cshtml
@@ -1,19 +1,19 @@
 ﻿@using Firehose.Web.Infrastructure
-@model Firehose.Web.Infrastructure.IAmACommunityMember
+@model IAmACommunityMember
 
 <div class="businessCard">
-    <span class="mugShot" style="background-image: url('@Model.EmailAddress.GravatarImage()');"></span>
+    <span class="mugShot" style="background-image: url('@Model.GravatarImage()');"></span>
     <p>
         <strong>@Model.FirstName @Model.LastName</strong><br />
         <span title="Readify | @Model.Title">@Model.Title</span><br />
         @Model.StateOrRegion<br />
         @if (Model is IAmAXamarinMVP || Model is IAmAMicrosoftMVP)
         {
-            string output;
-            var xvmpModel = Model as IAmAXamarinMVP;
-            if (xvmpModel != null)
+            var output = string.Empty;
+            var xmvpModel = Model as IAmAXamarinMVP;
+            if (xmvpModel != null)
             {
-                output += " Xamarin MVP since: " + xvmpModel.FirstAwarded.ToString("MMMM yyyy");
+                output += " Xamarin MVP since: " + xmvpModel.FirstAwarded.ToString("MMMM yyyy");
                 if (Model is IAmAMicrosoftMVP)
                 {
                     output += " and";


### PR DESCRIPTION
Added hash field for Gravatar so the e-mail is not required anymore.
This has a consequence; since the members are not available in the feed page right now (only the actual RSS feed is no more avatars there.

This should 'fix' #30 