### PR TITLE
added elmah at /logs without security

### DIFF
--- a/src/Firehose.Web/Firehose.Web.csproj
+++ b/src/Firehose.Web/Firehose.Web.csproj
@@ -51,6 +51,14 @@
       <HintPath>..\packages\BlogMonster.2.2.136.0\lib\net40\BlogMonster.dll</HintPath>
       <Private>True</Private>
     </Reference>
+    <Reference Include="Elmah, Version=1.2.13605.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\elmah.corelibrary.1.2\lib\Elmah.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Elmah.Mvc, Version=2.1.2.1389, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Elmah.Mvc.2.1.2\lib\net40\Elmah.Mvc.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="MarkdownSharp">
       <HintPath>..\packages\MarkdownSharp.1.13.0.0\lib\35\MarkdownSharp.dll</HintPath>
     </Reference>

--- a/src/Firehose.Web/Web.config
+++ b/src/Firehose.Web/Web.config
@@ -5,6 +5,14 @@
   http://go.microsoft.com/fwlink/?LinkId=301880
   -->
 <configuration>
+  <configSections>
+    <sectionGroup name="elmah">
+      <section name="security" requirePermission="false" type="Elmah.SecuritySectionHandler, Elmah" />
+      <section name="errorLog" requirePermission="false" type="Elmah.ErrorLogSectionHandler, Elmah" />
+      <section name="errorMail" requirePermission="false" type="Elmah.ErrorMailSectionHandler, Elmah" />
+      <section name="errorFilter" requirePermission="false" type="Elmah.ErrorFilterSectionHandler, Elmah" />
+    </sectionGroup>
+  </configSections>
   <appSettings>
     <add key="webpages:Version" value="3.0.0.0" />
     <add key="webpages:Enabled" value="false" />
@@ -17,6 +25,14 @@
     <add key="RssFeedDescription" value="An aggregated feed from the Xamarin community" />
     <add key="RssFeedImageUrl" value="https://www.planetxamarin.com/Content/Logo.png" />
     <add key="DefaultGravatarImage" value="mm" />
+    <add key="elmah.mvc.disableHandler" value="false" />
+    <add key="elmah.mvc.disableHandleErrorFilter" value="false" />
+    <add key="elmah.mvc.requiresAuthentication" value="false" />
+    <add key="elmah.mvc.IgnoreDefaultRoute" value="true" />
+    <add key="elmah.mvc.allowedRoles" value="*" />
+    <add key="elmah.mvc.allowedUsers" value="*" />
+    <add key="elmah.mvc.route" value="logs" />
+    <add key="elmah.mvc.UserAuthCaseSensitive" value="true" />
   </appSettings>
   <system.web>
     <compilation debug="true" targetFramework="4.5.1">
@@ -24,6 +40,11 @@
       </assemblies>
     </compilation>
     <httpRuntime targetFramework="4.5.1" />
+    <httpModules>
+      <add name="ErrorLog" type="Elmah.ErrorLogModule, Elmah" />
+      <add name="ErrorMail" type="Elmah.ErrorMailModule, Elmah" />
+      <add name="ErrorFilter" type="Elmah.ErrorFilterModule, Elmah" />
+    </httpModules>
   </system.web>
   <runtime>
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
@@ -42,6 +63,10 @@
       <dependentAssembly>
         <assemblyIdentity name="Autofac" publicKeyToken="17863af14b0044da" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-4.2.1.0" newVersion="4.2.1.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Web" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.0.0" newVersion="4.0.0.0" />
       </dependentAssembly>
     </assemblyBinding>
   </runtime>
@@ -69,5 +94,13 @@
       <remove fileExtension=".svg" />
       <mimeMap fileExtension=".svg" mimeType="image/svg+xml" />
     </staticContent>
+    <validation validateIntegratedModeConfiguration="false" />
+    <modules>
+      <add name="ErrorLog" type="Elmah.ErrorLogModule, Elmah" preCondition="managedHandler" />
+      <add name="ErrorMail" type="Elmah.ErrorMailModule, Elmah" preCondition="managedHandler" />
+      <add name="ErrorFilter" type="Elmah.ErrorFilterModule, Elmah" preCondition="managedHandler" />
+    </modules>
   </system.webServer>
+  <elmah>
+  </elmah>
 </configuration>

--- a/src/Firehose.Web/packages.config
+++ b/src/Firehose.Web/packages.config
@@ -4,6 +4,8 @@
   <package id="Autofac.Mvc5" version="4.0.0" targetFramework="net451" />
   <package id="BlogMonster" version="2.2.136.0" targetFramework="net451" />
   <package id="bootstrap" version="3.3.7" targetFramework="net451" />
+  <package id="elmah.corelibrary" version="1.2" targetFramework="net451" />
+  <package id="Elmah.Mvc" version="2.1.2" targetFramework="net451" />
   <package id="jQuery" version="3.1.1" targetFramework="net451" />
   <package id="MarkdownSharp" version="1.13.0.0" targetFramework="net451" />
   <package id="Microsoft.AspNet.Mvc" version="5.2.3" targetFramework="net451" />

--- a/src/Firehose.Web/robots.txt
+++ b/src/Firehose.Web/robots.txt
@@ -9,3 +9,4 @@
 
 User-agent: *
 Disallow: /feed
+Disallow: /logs


### PR DESCRIPTION
So we (or anyone) can remotely diagnose failures.

This is secure/safe as long as the following conditions are met:

* The website remains stateless.
* The website does not accept user input.
* We do not define any environment variables within the Azure PaaS.
* We do not store any secrets in the `Web.config`