### PR TITLE
Attempt to try and fix #195

### DIFF
--- a/src/Firehose.Web/Firehose.Web.csproj
+++ b/src/Firehose.Web/Firehose.Web.csproj
@@ -239,6 +239,9 @@
     <Compile Include="App_Start\ContainerConfig.cs" />
     <Compile Include="App_Start\IoC.cs" />
     <Compile Include="App_Start\RouteConfig.cs" />
+    <Compile Include="Authors\AlexandrSorokoletov.cs" />
+    <Compile Include="Authors\AloisDeniel.cs" />
+    <Compile Include="Authors\GoneMobile.cs" />
     <Compile Include="Authors\MalcolmJack.cs" />
     <Compile Include="Authors\AdamPatridge.cs" />
     <Compile Include="Authors\CanBilgin.cs" />
@@ -304,7 +307,7 @@
     <Compile Include="Authors\TheXamarinShow.cs" />
     <Compile Include="Authors\OfficialXamarinBlog.cs" />
     <Compile Include="Authors\JonDick.cs" />
-     <Compile Include="Authors\DileepaRajapaksa.cs" />
+    <Compile Include="Authors\DileepaRajapaksa.cs" />
     <Compile Include="Authors\JohnMiller.cs" />
     <Compile Include="Authors\MarcBruins.cs" />
     <Compile Include="Authors\ChrisHamons.cs" />


### PR DESCRIPTION
This tries to load the url and parse the feed, if anything happens the author is excluded. While this fixes most of the instability it will hit performance. Although, when cached it should be OK for a while.

I don't see any other apparent way to fix this without turning the complete loading of feeds from bloggers upside down.