### PR TITLE
Proposed fix for #239

### DIFF
--- a/src/Firehose.Web/Infrastructure/CombinedFeedSource.cs
+++ b/src/Firehose.Web/Infrastructure/CombinedFeedSource.cs
@@ -98,7 +98,7 @@ namespace Firehose.Web.Infrastructure
                         var feed = SyndicationFeed.Load(xmlReader);
                         var filteredItems = feed.Items
                             .Where(filter)
-                            .Where(item => item.LastUpdatedTime <= DateTimeOffset.Now && item.PublishDate <= DateTimeOffset.Now)
+                            .Where(item => item.LastUpdatedTime.UtcDateTime <= DateTimeOffset.UtcNow && item.PublishDate.UtcDateTime <= DateTimeOffset.UtcNow)
                             .ToArray();
 
                         var itemsField = feed.GetType().GetField("items", BindingFlags.Instance | BindingFlags.NonPublic);

--- a/src/Firehose.Web/Infrastructure/CombinedFeedSource.cs
+++ b/src/Firehose.Web/Infrastructure/CombinedFeedSource.cs
@@ -98,6 +98,7 @@ namespace Firehose.Web.Infrastructure
                         var feed = SyndicationFeed.Load(xmlReader);
                         var filteredItems = feed.Items
                             .Where(filter)
+                            .Where(item => item.LastUpdatedTime <= DateTimeOffset.Now && item.PublishDate <= DateTimeOffset.Now)
                             .ToArray();
 
                         var itemsField = feed.GetType().GetField("items", BindingFlags.Instance | BindingFlags.NonPublic);


### PR DESCRIPTION
All feeds are now filtered by last update _and_ created date. Both dates must be today or before today.