### PR TITLE
Updated content filter for my blog

### DIFF
--- a/src/Firehose.Web/Authors/CharlinAgramonte.cs
+++ b/src/Firehose.Web/Authors/CharlinAgramonte.cs
@@ -22,7 +22,6 @@ namespace Firehose.Web
         public IEnumerable<Uri> FeedUris { get { yield return new Uri("https://xamgirl.com/rss"); } }
 
         public bool Filter(SyndicationItem item) =>
-                item.Title.Text.ToLowerInvariant().Contains("xamarin") ||
                 item.Categories.Any(category => category.Name.ToLowerInvariant().Contains("xamarin"));
     }
 }


### PR DESCRIPTION
Updated filter to just show content categorized as Xamarin

If you are submitting a new blog please read:

By sending this pull request to add my blog I verify that I adhere to the Planet Xamarin blog guidelines (please check each item that applies):

- [x] I have a valid blog & RSS URL
- [x] I host NO malicious or offensive content on the blog (including photos, swearing, etc.)
- [x] My blog is active with at least 3 Xamarin related blog posts in the last 6 months
- [x] I have applied a filter (Optional: if blog is only about Xamarin)
- [x] I understand, if I delete my blog, I will be deleted from Planet Xamarin
- [x] I understand, my blog may be removed at any time if any of these guidelines are broken.
