### PR TITLE
HTTPS for GoneMobile.io rss feed

### DIFF
--- a/src/Firehose.Web/Authors/GoneMobile.cs
+++ b/src/Firehose.Web/Authors/GoneMobile.cs
@@ -16,11 +16,13 @@ namespace Firehose.Web.Authors
 
         public string ShortBioOrTagLine => "is a development podcast focused on mobile development hosted by Jon Dick and Greg Shackles.";
 
+        // TEMPORARY WORKAROUND - We'll get https support shortly, for now we have it for the feed at least
         public Uri WebSite => new Uri("http://gonemobile.io");
 
         public IEnumerable<Uri> FeedUris
         {
-            get { yield return new Uri("http://gonemobile.io/podcast.rss"); }
+            // TEMPORARY WORKAROUND - We'll have proper https support in fireside soon and can use https://gonemobile.io/rss at that point
+            get { yield return new Uri("https://gonemobile.fireside.fm/rss"); }
         }
 
         public string TwitterHandle => "gonemobilecast";

--- a/src/Firehose.Web/Authors/GoneMobile.cs
+++ b/src/Firehose.Web/Authors/GoneMobile.cs
@@ -21,8 +21,7 @@ namespace Firehose.Web.Authors
 
         public IEnumerable<Uri> FeedUris
         {
-            // TEMPORARY WORKAROUND - We'll have proper https support in fireside soon and can use https://gonemobile.io/rss at that point
-            get { yield return new Uri("https://gonemobile.fireside.fm/rss"); }
+            get { yield return new Uri("https://feed.gonemobile.io"); }
         }
 
         public string TwitterHandle => "gonemobilecast";


### PR DESCRIPTION
This is an interim update to get rss feed https support while we wait for fireside.fm to roll out https support for custom domains (which is supposed to be coming soon).