### PR TITLE
More feed tests

### DIFF
--- a/src/Firehose.Web/Authors/AlejandroRuiz.cs
+++ b/src/Firehose.Web/Authors/AlejandroRuiz.cs
@@ -16,11 +16,11 @@ namespace Firehose.Web.Authors
 
 		public string EmailAddress => "alejandro@alejandroruizvarela.com";
 
-		public Uri WebSite => new Uri("http://alejandroruizvarela.blogspot.mx");
+		public Uri WebSite => new Uri("https://alejandroruizvarela.blogspot.mx");
 
 		public IEnumerable<Uri> FeedUris
 		{
-			get { yield return new Uri("http://alejandroruizvarela.blogspot.mx/rss.xml"); }
+			get { yield return new Uri("https://alejandroruizvarela.blogspot.mx/rss.xml"); }
 		}
 
 		public string TwitterHandle => "alejandroruizva";

--- a/src/Firehose.Web/Authors/ChrisWilliams.cs
+++ b/src/Firehose.Web/Authors/ChrisWilliams.cs
@@ -13,11 +13,11 @@ namespace Firehose.Web.Authors
         public string TwitterHandle => "crswlls";
         public string GravatarHash => "21e379df7ba9c57f167188e2fcb7dd75";
         public string StateOrRegion => "Bristol, UK";
-        public Uri WebSite => new Uri("http://crswlls.wordpress.com");
+        public Uri WebSite => new Uri("https://crswlls.wordpress.com");
 
         public IEnumerable<Uri> FeedUris
         {
-            get { yield return new Uri("http://crswlls.wordpress.com/rss/"); }
+            get { yield return new Uri("https://crswlls.wordpress.com/rss/"); }
         }
 
         public string GitHubHandle => string.Empty;

--- a/src/Firehose.Web/Authors/Suthahar.cs
+++ b/src/Firehose.Web/Authors/Suthahar.cs
@@ -25,7 +25,7 @@ namespace Firehose.Web.Authors
         public GeoPosition Position => new GeoPosition(12.9715990, 77.5945630);
         public IEnumerable<Uri> FeedUris
         {
-            get { yield return new Uri("http://xamarininterviewquestion.blogspot.in/feeds/posts/default"); }
+            get { yield return new Uri("https://xamarininterviewquestion.blogspot.in/feeds/posts/default"); }
         }
 
         public string GitHubHandle => "jssuthahar";

--- a/src/Firehose.Web/Firehose.Web.csproj
+++ b/src/Firehose.Web/Firehose.Web.csproj
@@ -339,7 +339,7 @@
     <Compile Include="Authors\IoneSouzaJunior.cs" />
     <Compile Include="Authors\DavidBritch.cs" />
     <Compile Include="Authors\AlejandroRuiz.cs" />
-    <Compile Include="Authors\SebastianSeidel.cs" />
+    <None Include="Authors\SebastianSeidel.cs" />
     <Compile Include="Authors\AlessandroCaliaro.cs" />
     <Compile Include="Authors\JonPeppers.cs" />
     <Compile Include="Authors\MarioGalvan.cs" />

--- a/src/Firehose.Web/Infrastructure/CombinedFeedSource.cs
+++ b/src/Firehose.Web/Infrastructure/CombinedFeedSource.cs
@@ -30,8 +30,7 @@ namespace Firehose.Web.Infrastructure
             var cached = new Cached<ISyndicationFeedSource>(TimeSpan.FromHours(1), new SystemClock(), LoadFeeds);
             _combinedFeedSource = new Lazy<Cached<ISyndicationFeedSource>>(() => cached, LazyThreadSafetyMode.PublicationOnly);
 
-            ServicePointManager.SecurityProtocol = SecurityProtocolType.Tls12 | SecurityProtocolType.Tls11 |
-                                                              SecurityProtocolType.Tls | SecurityProtocolType.Ssl3;
+            ServicePointManager.SecurityProtocol = SecurityProtocolType.Tls12 | SecurityProtocolType.Tls11;
 
             HttpClient.DefaultRequestHeaders.UserAgent.Add(new ProductInfoHeaderValue("PlanetXamarin", $"{GetType().Assembly.GetName().Version}"));
             HttpClient.Timeout = TimeSpan.FromMinutes(1);

--- a/src/UnitTest/AuthorsTest.cs
+++ b/src/UnitTest/AuthorsTest.cs
@@ -1,7 +1,14 @@
 ﻿using Firehose.Web.Infrastructure;
+using Polly;
+using System;
+using System.Collections.Generic;
 using System.Linq;
+using System.Net;
+using System.Net.Http;
 using System.Reflection;
+using System.Threading.Tasks;
 using Xunit;
+using Xunit.Abstractions;
 
 namespace UnitTest
 {
@@ -17,6 +24,21 @@ namespace UnitTest
             nameof(IAmANewsletter),
             nameof(IAmAFrameworkForXamarin)
         };
+
+        readonly ITestOutputHelper _output;
+
+        Policy _policy = Policy.Handle<WebException>(
+            ex => !ex.Message.Contains("Could not create SSL/TLS secure channel"))
+            .WaitAndRetryAsync(3, retryAttempt =>
+                TimeSpan.FromSeconds(Math.Pow(2, retryAttempt)));
+        static HttpClient _httpClient = new HttpClient();
+
+        public AuthorsTest(ITestOutputHelper output)
+        {
+            _output = output;
+
+            ServicePointManager.SecurityProtocol = SecurityProtocolType.Tls12 | SecurityProtocolType.Tls11;
+        }
 
         [Fact]
         public void All_Authors_Implement_Interface()
@@ -40,14 +62,51 @@ namespace UnitTest
             var assembly = Assembly.GetAssembly(typeof(IAmACommunityMember));
 
             var types = assembly.GetTypes();
-            var authors = types.Where(t => typeof(IAmACommunityMember).IsAssignableFrom(t)).ToArray();
+            var authors = types.Where(t => typeof(IAmACommunityMember).IsAssignableFrom(t) && 
+                !_interfaceNames.Contains(t.Name)).ToArray();
 
             foreach(var author in authors)
             {
-                if (_interfaceNames.Contains(author.Name)) continue;
-
                 Assert.True(author.Namespace == "Firehose.Web.Authors",
                     $"{author.Name} is not in the correct namespace");
+            }
+        }
+
+        [Fact]
+        public async Task All_Authors_Have_Secure_Feed()
+        {
+            var assembly = Assembly.GetAssembly(typeof(IAmACommunityMember));
+
+            var types = assembly.GetTypes();
+            var authorTypes = types.Where(t => typeof(IAmACommunityMember).IsAssignableFrom(t) &&
+                !_interfaceNames.Contains(t.Name)).ToArray();
+
+            var hitFeedTasks = new List<Task>();
+            foreach(var authorType in authorTypes)
+            {
+                var author = (IAmACommunityMember)Activator.CreateInstance(authorType);
+                foreach(var feed in author.FeedUris)
+                {
+                    Assert.Equal("https", feed.Scheme);
+
+                    // hit the url to see if it responds!
+                    hitFeedTasks.Add(HitFeedAsync(feed));
+                }
+            }
+
+            await Task.WhenAll(hitFeedTasks).ConfigureAwait(false);
+        }
+
+        private async Task HitFeedAsync(Uri feedUrl)
+        {
+            try
+            {
+                await _policy.ExecuteAsync(() => _httpClient.GetAsync(feedUrl))
+                    .ConfigureAwait(false);
+            }
+            catch
+            {
+                _output.WriteLine($"{feedUrl} sucks...");
             }
         }
     }

--- a/src/UnitTest/UnitTest.csproj
+++ b/src/UnitTest/UnitTest.csproj
@@ -5,6 +5,8 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Polly" Version="5.8.0" />
+    <PackageReference Include="System.Net.Http" Version="4.3.3" />
     <PackageReference Include="xunit" Version="2.3.1" />
     <PackageReference Include="xunit.analyzers" Version="0.8.0" />
     <PackageReference Include="xunit.runner.console" Version="2.3.1" />


### PR DESCRIPTION
- Disallows SSL and TLS v1.0 as they are obsolete.
- Adds tests to validate schema of feed URI's and hits the URI to check if there is a valid response
- Switches leftover authors' feeds to https
- Disables @CayasSoftware's feed until it is https
