### PR TITLE
Only add distinct item to combined feed

### DIFF
--- a/src/Firehose.Web/Authors/EvgenyZborovsky.cs
+++ b/src/Firehose.Web/Authors/EvgenyZborovsky.cs
@@ -1,0 +1,29 @@
+﻿using System;
+using System.Collections.Generic;
+using Firehose.Web.Infrastructure;
+
+namespace Firehose.Web.Authors
+{
+    public class EvgenyZborovsky : IAmACommunityMember
+    {
+        public string FirstName => "Evgeny";
+        public string LastName => "Zborovsky";
+        public string StateOrRegion => "Estonia";
+        public string EmailAddress => "yuv4ik@gmail.com";
+        public string ShortBioOrTagLine => "Xamarin Enthusiast";
+        public Uri WebSite => new Uri("https://smellyc0de.wordpress.com/");
+        public IEnumerable<Uri> FeedUris
+        {
+            get 
+            { 
+                yield return new Uri("https://smellyc0de.wordpress.com/tag/xamarin-forms/feed/");
+                yield return new Uri("https://smellyc0de.wordpress.com/tag/xamarin/feed/");
+            }
+        }
+        public string TwitterHandle => "ezborovsky";
+        public string GravatarHash => "b8a0ab8445fafb38afdf26cb976df32f";
+        public string GitHubHandle => "yuv4ik";
+        public GeoPosition Position => new GeoPosition(58.3750372, 26.6625567);
+        public string FeedLanguageCode => "en";
+    }
+}

--- a/src/Firehose.Web/Controllers/FeedController.cs
+++ b/src/Firehose.Web/Controllers/FeedController.cs
@@ -5,6 +5,7 @@ using System.Reflection;
 using System.ServiceModel.Syndication;
 using System.Web.Mvc;
 using BlogMonster.Web;
+using Firehose.Web.Extensions;
 using Firehose.Web.Infrastructure;
 
 namespace Firehose.Web.Controllers
@@ -39,6 +40,7 @@ namespace Firehose.Web.Controllers
                 if (numPosts == null) return originalFeed;
 
                 var items = _combinedFeedSource.GetFeed(language).Items
+                    .DistinctBy(i => i.Id)
                     .OrderByDescending(item => item.PublishDate)
                     .Take((int)numPosts)
                     .ToArray();

--- a/src/Firehose.Web/Controllers/PreviewController.cs
+++ b/src/Firehose.Web/Controllers/PreviewController.cs
@@ -2,6 +2,7 @@
 using System.Reflection;
 using System.ServiceModel.Syndication;
 using System.Web.Mvc;
+using Firehose.Web.Extensions;
 using Firehose.Web.Infrastructure;
 using Firehose.Web.ViewModels;
 
@@ -33,6 +34,7 @@ namespace Firehose.Web.Controllers
             if (numPosts == null) return originalFeed;
 
             var items = _combinedFeedSource.Feed.Items
+                                           .DistinctBy(i => i.Id)
                                            .OrderByDescending(item => item.PublishDate)
                                            .Take((int)numPosts)
                                            .ToArray();

--- a/src/Firehose.Web/Extensions/IEnumerableExtensions.cs
+++ b/src/Firehose.Web/Extensions/IEnumerableExtensions.cs
@@ -1,0 +1,20 @@
+﻿using System;
+using System.Collections.Generic;
+
+namespace Firehose.Web.Extensions
+{
+    public static class IEnumerableExtensions
+    {
+        public static IEnumerable<TSource> DistinctBy<TSource>(this IEnumerable<TSource> source, Func<TSource, string> keySelector)
+        {
+            var seenKeys = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+            foreach (TSource element in source)
+            {
+                if (seenKeys.Add(keySelector(element)))
+                {
+                    yield return element;
+                }
+            }
+        }
+    }
+}

--- a/src/Firehose.Web/Firehose.Web.csproj
+++ b/src/Firehose.Web/Firehose.Web.csproj
@@ -361,6 +361,7 @@
     <Compile Include="Authors\SaturninoPimentel.cs" />
     <Compile Include="Authors\CharlinAgramonte.cs" />
     <Compile Include="Authors\MarcosCobenaMorian.cs" />
+    <Compile Include="Authors\EvgenyZborovsky.cs" />
   </ItemGroup>
   <ItemGroup>
     <Content Include="Views\web.config" />

--- a/src/Firehose.Web/Firehose.Web.csproj
+++ b/src/Firehose.Web/Firehose.Web.csproj
@@ -363,6 +363,7 @@
     <Compile Include="Authors\CharlinAgramonte.cs" />
     <Compile Include="Authors\MarcosCobenaMorian.cs" />
     <Compile Include="Authors\EvgenyZborovsky.cs" />
+    <Compile Include="Extensions\IEnumerableExtensions.cs" />
   </ItemGroup>
   <ItemGroup>
     <Content Include="Views\web.config" />

--- a/src/UnitTest/IEnumerableExtensionsTest.cs
+++ b/src/UnitTest/IEnumerableExtensionsTest.cs
@@ -1,0 +1,55 @@
+﻿using System.Linq;
+using System.ServiceModel.Syndication;
+using Firehose.Web.Extensions;
+using Xunit;
+
+namespace UnitTest
+{
+    public class IEnumerableExtensionsTest
+    {
+        [Fact]
+        public void DistinctBySyndicationItemId_WithDuplicateIds_Test()
+        {
+            var items = new SyndicationItem[]
+            {
+                new SyndicationItem { Id = "http://blog.com/?p=23" },
+                new SyndicationItem { Id = "http://blog.com/?p=23" }
+            };
+
+            var filteredItems = items.DistinctBy(i => i.Id).ToList();
+            Assert.Single(filteredItems);
+        }
+
+        [Fact]
+        public void DistinctBySyndicationItemId_WithDuplicateIdsInDifferentLetterCases_Test()
+        {
+            var items = new SyndicationItem[]
+            {
+                new SyndicationItem { Id = "http://blog.com/?p=23" },
+                new SyndicationItem { Id = "http://blog.com/?P=23" }
+            };
+            var filteredItems = items.DistinctBy(i => i.Id).ToList();
+            Assert.Single(filteredItems);
+        }
+
+        [Fact]
+        public void DistinctBySyndicationItemId_WithoutDuplicateIds_Test()
+        {
+            var items = new SyndicationItem[]
+            {
+                new SyndicationItem { Id = "http://blog.com/?p=23" },
+                new SyndicationItem { Id = "http://blog.com/?p=24" }
+            };
+            var filteredItems = items.DistinctBy(i => i.Id).ToList();
+            Assert.Equal(items.Length, filteredItems.Count);
+        }
+
+        [Fact]
+        public void DistinctBySyndicationItemId_WithEmptyArray_Test()
+        {
+            var items = new SyndicationItem[] { };
+            var filteredItems = items.DistinctBy(i => i.Id).ToList();
+            Assert.Equal(items.Length, filteredItems.Count);
+        }
+    }
+}


### PR DESCRIPTION
If a feed item (blogpost) will appear in multiple FeedUris of the same author it will also appear multiple times in the aggregated feed. Original issue #443 

Implemented solution: using distinct by SyndicationItem.Id which is normally a url of the feed item.

Fixes #443 