### PR TITLE
Removed John Miller due to expired SSL

### DIFF
--- a/src/Firehose.Web/Firehose.Web.csproj
+++ b/src/Firehose.Web/Firehose.Web.csproj
@@ -288,7 +288,6 @@
     <Compile Include="Authors\TheXamarinShow.cs" />
     <Compile Include="Authors\OfficialXamarinBlog.cs" />
     <Compile Include="Authors\JonDick.cs" />
-    <Compile Include="Authors\JohnMiller.cs" />
     <Compile Include="Authors\MarcBruins.cs" />
     <Compile Include="Authors\ChrisHamons.cs" />
     <Compile Include="Authors\MichaelRidland.cs" />


### PR DESCRIPTION
@therealjohn tried to notify you on Twitter, your SSL cert seems expired on your domain. Please fix to be included again.