### PR TITLE
Fix Preview on Web Site

### DIFF
--- a/src/Firehose.Web/ViewModels/PreviewViewModel.cs
+++ b/src/Firehose.Web/ViewModels/PreviewViewModel.cs
@@ -27,6 +27,9 @@ namespace Firehose.Web.ViewModels
 					if (authorHosts.Contains(host))
 						return true;
 
+					if (authorHosts.Contains(host.Replace("www.", "")))
+						return true;
+
 					if (host.Contains("feedproxy.google")) //  feed burner is messed up :(
 					{
 						// url will look like:

--- a/src/Firehose.Web/ViewModels/PreviewViewModel.cs
+++ b/src/Firehose.Web/ViewModels/PreviewViewModel.cs
@@ -49,13 +49,13 @@ namespace Firehose.Web.ViewModels
 			var items = new List<PreviewModelItem>();
 			foreach(var item in feed.Items)
 			{
-				var author = authors.FirstOrDefault(b => MatchesAuthorUrls(b, item.Links.Select(l => l.Uri)));
+				var author = authors.FirstOrDefault(a => MatchesAuthorUrls(a, item.Links.Select(l => l.Uri)));
 
 				string authorName;
 
 				if (author != null)
 				{
-					authorName = author.FirstName + " " + author.LastName;
+					authorName = $"{author.FirstName} {author.LastName}".Trim();
 				}
 				// If no author was matched, extract the name from the RSS feed, something is better than nothing right?!
 				else


### PR DESCRIPTION
After #636 was merged, we have some minor issues with the preview on the site.

- Fixed issue where we where taking n amount of posts for the preview, _then_ sorting by date. However it should be the other way around.
- Fixed issue where feed authors which use Google FeedBurner will show up blank in the preview, since FeedBurner uses proxied URL's which do not directly match up with authors FeedUri's
- Fixed issue where itunes feeds won't show any author information about blog post