### PR TITLE
Fix getting feed with lang query is empty

### DIFF
--- a/src/Firehose.Web/Controllers/FeedController.cs
+++ b/src/Firehose.Web/Controllers/FeedController.cs
@@ -16,20 +16,20 @@ namespace Firehose.Web.Controllers
         }
 
         [Route("feed")]
-        public RssFeedResult Index(int? numPosts = 50, string lang = "")
+        public RssFeedResult Index(int? numPosts = 150, string lang = "mixed")
         {
             var feed = GetFeed(numPosts, lang);
             return new RssFeedResult(feed);
         }
 
-        private SyndicationFeed GetFeed(int? numPosts, string lang = "")
+        private SyndicationFeed GetFeed(int? numPosts = 150, string lang = "mixed")
         {
             SyndicationFeed originalFeed = null;
 
             try
             {
                 string language = null;
-                if (!string.IsNullOrEmpty(lang))
+                if (!string.IsNullOrEmpty(lang) && lang != "mixed")
                     language = CultureInfo.CreateSpecificCulture(lang).Name;
 
                 originalFeed = _combinedFeedSource.LoadFeed(numPosts, language).GetAwaiter().GetResult();

--- a/src/Firehose.Web/Controllers/PreviewController.cs
+++ b/src/Firehose.Web/Controllers/PreviewController.cs
@@ -1,4 +1,5 @@
-﻿using System.Linq;
+﻿using System.Globalization;
+using System.Linq;
 using System.ServiceModel.Syndication;
 using System.Web.Mvc;
 using Firehose.Web.Infrastructure;
@@ -16,16 +17,17 @@ namespace Firehose.Web.Controllers
         }
 
         [Route("preview")]
-        public ViewResult Index(int? numPosts = 50)
+        public ViewResult Index()
         {
-            var feed = GetFeed(numPosts);
+            var feed = GetFeed();
             return View(new PreviewViewModel(feed, _combinedFeedSource.Tamarins.ToArray()));
         }
 
-        private SyndicationFeed GetFeed(int? numPosts)
+        private SyndicationFeed GetFeed()
         {
-            var originalFeed = _combinedFeedSource.LoadFeed(numPosts, "en").GetAwaiter().GetResult();
-            return originalFeed;
+			var lang = CultureInfo.CreateSpecificCulture("en").Name;
+			var feed = _combinedFeedSource.LoadFeed(50, lang).GetAwaiter().GetResult();
+            return feed;
         }
     }
 }

--- a/src/Firehose.Web/Infrastructure/NewCombinedFeedSource.cs
+++ b/src/Firehose.Web/Infrastructure/NewCombinedFeedSource.cs
@@ -6,6 +6,7 @@ using Polly.Wrap;
 using System;
 using System.Collections.Generic;
 using System.Configuration;
+using System.Globalization;
 using System.Linq;
 using System.Net;
 using System.Net.Http;
@@ -72,7 +73,7 @@ namespace Firehose.Web.Infrastructure
             }
             else
             {
-                tamarins = Tamarins.Where(t => t.FeedLanguageCode == languageCode);
+                tamarins = Tamarins.Where(t => CultureInfo.CreateSpecificCulture(t.FeedLanguageCode).Name == languageCode);
             }
 
             var feedTasks = tamarins.SelectMany(t => TryReadFeeds(t, GetFilterFunction(t)));

--- a/src/Firehose.Web/Infrastructure/NewCombinedFeedSource.cs
+++ b/src/Firehose.Web/Infrastructure/NewCombinedFeedSource.cs
@@ -34,7 +34,7 @@ namespace Firehose.Web.Infrastructure
 				// cache in memory for an hour
 				var memoryCache = new MemoryCache(new MemoryCacheOptions());
 				var memoryCacheProvider = new MemoryCacheProvider(memoryCache);
-				var cachePolicy = Policy.CacheAsync(memoryCacheProvider, TimeSpan.FromHours(1));
+				var cachePolicy = Policy.CacheAsync(memoryCacheProvider, TimeSpan.FromHours(1), OnCacheError);
 
 				// retry policy with max 2 retries, delay by x*x^1.2 where x is retry attempt
 				// this will ensure we don't retry too quickly
@@ -44,8 +44,13 @@ namespace Firehose.Web.Infrastructure
 				policy = Policy.WrapAsync(cachePolicy, retryPolicy);
 			}
         }
-        
-        private void EnsureHttpClient()
+
+		private void OnCacheError(Context arg1, string arg2, Exception arg3)
+		{
+			Logger.Error(arg3, $"Failed caching item: {arg1} - {arg2}");
+		}
+
+		private void EnsureHttpClient()
         {
             if (httpClient == null)
             {

--- a/src/Firehose.Web/Views/Home/Index.cshtml
+++ b/src/Firehose.Web/Views/Home/Index.cshtml
@@ -26,7 +26,7 @@
         <h1>Can I just read it here?</h1>
         <p>
             You can, but we don't want to redirect traffic from our people's individual sites. Here's a
-            <a href="@(Url.UrlFor<PreviewController>(c => c.Index(null)))">sneak peek</a> in case you're still trying to decide
+            <a href="@(Url.UrlFor<PreviewController>(c => c.Index()))">sneak peek</a> in case you're still trying to decide
             to subscribe.
         </p>
     </div>


### PR DESCRIPTION
This should fix #651, we are parsing the lang query into a name from CultureInfo, which we were passing along to the feed infrastructure. However, we were not doing the same conversion with blogger `FeedLanguage` properties. So it was returning no bloggers when using the `lang` query.

Also in this PR. Before, I tried to cache the result from each blogger feed. However, it is much more performant just caching the combined feed we return to the user.