### PR TITLE
Removing item check from feed test

### DIFF
--- a/src/UnitTest/AuthorsTest.cs
+++ b/src/UnitTest/AuthorsTest.cs
@@ -84,10 +84,6 @@ namespace UnitTest
 				var feed = await feedSource.LoadFeed(null).ConfigureAwait(false);
 
 				Assert.NotNull(feed);
-
-				var allItems = feed.Items.Where(i => i != null).ToList();
-
-				Assert.True(allItems?.Count > 0, $"Author {author?.FirstName} {author?.LastName} @{author?.GitHubHandle} doesn't meet post policy {author?.FeedUris?.FirstOrDefault()?.OriginalString}");
 			}
 			catch (Exception ex)
 			{


### PR DESCRIPTION
@jamesmontemagno I'm proposing this change to the Author_Has_Secure_And_Parseable_Feed test.

Currently the test fails for several authors. If you take one as an example - Jim Bennett - his feed is valid and parsable. He just doesn't have any Xamarin tagged posts lately. I don't believe we want to remove Jim Bennett from the list of authors 😲, but I mean, that's up to you. 

The test name suggests it should only check for secureness and parsability so all I'm doing is removing the part that checks for recent items.