### PR TITLE
Update FeedUris for JohnTaubensee

### DIFF
--- a/src/Firehose.Web/Authors/JohnTaubensee.cs
+++ b/src/Firehose.Web/Authors/JohnTaubensee.cs
@@ -17,7 +17,7 @@ namespace Firehose.Web.Authors
 
         public IEnumerable<Uri> FeedUris
         {
-            get { yield return new Uri("https://taubensee.net/rss"); }
+            get { yield return new Uri("https://taubensee.net/tags/xamarin/index.xml"); }
         }
 
         public string TwitterHandle => "jtaubensee";


### PR DESCRIPTION
Updating `FeedUris` for existing blog. I recently migrated from Ghost to Hugo and have a new RSS endpoint.