### PR TITLE
Add web.config to preload slow pages on app service

### DIFF
--- a/src/Firehose.WebCore/web.config
+++ b/src/Firehose.WebCore/web.config
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+
+  <!-- Simplistic cache warmup by preloading page - could switch to hosted service or health check
+	https://docs.microsoft.com/en-us/azure/app-service/deploy-staging-slots#specify-custom-warm-up 
+  -->
+	<system.webServer>
+		<applicationInitialization>
+			<add initializationPage="/preview" />
+			<add initializationPage="/feed" />
+		</applicationInitialization>
+	</system.webServer>
+</configuration>


### PR DESCRIPTION
Simplistic cache warmup by preloading page - could switch to hosted service or health check in the future, but this will preload the preview and feed urls on app startup / slot switch for Azure App Service.

https://docs.microsoft.com/en-us/azure/app-service/deploy-staging-slots#specify-custom-warm-up 