### PR TITLE
Update action to use newest download-artifact

### DIFF
--- a/.github/workflows/PlanetWebsiteService.yml
+++ b/.github/workflows/PlanetWebsiteService.yml
@@ -37,7 +37,7 @@ jobs:
     needs: build
     steps:
     - name: Download artifact from build job
-      uses: actions/download-artifact@v2
+      uses: actions/download-artifact@v3
       with:
         name: webapp
         path: ${{ env.AZURE_WEBAPP_PACKAGE_PATH }}


### PR DESCRIPTION
Action has lots of warnings on set-output, it looks like updating from v2 to v3 will fix some / most.